### PR TITLE
Separate nonlinear gaussian from transition

### DIFF
--- a/src/probnum/problems/zoo/filtsmooth/_filtsmooth_problems.py
+++ b/src/probnum/problems/zoo/filtsmooth/_filtsmooth_problems.py
@@ -114,7 +114,7 @@ def car_tracking(
         proc_noise_cov_cholesky=measurement_cov_cholesky,
         forward_implementation=forward_implementation,
         backward_implementation=backward_implementation,
-    )
+    ).as_continuous_transition()
 
     if initrv is None:
         initrv = randvars.Normal(
@@ -223,7 +223,7 @@ def ornstein_uhlenbeck(
         proc_noise_cov_mat=measurement_variance * np.eye(1),
         forward_implementation=forward_implementation,
         backward_implementation=backward_implementation,
-    )
+    ).as_continuous_transition()
 
     if initrv is None:
         initrv = randvars.Normal(10.0 * np.ones(1), np.eye(1))
@@ -327,23 +327,23 @@ def pendulum(
     g = 9.81
 
     # Define non-linear dynamics and measurements
-    def f(t, x):
+    def f(x):
         x1, x2 = x
         y1 = x1 + x2 * step
         y2 = x2 - g * np.sin(x1) * step
         return np.array([y1, y2])
 
-    def df(t, x):
+    def df(x):
         x1, _ = x
         y1 = [1, step]
         y2 = [-g * np.cos(x1) * step, 1]
         return np.array([y1, y2])
 
-    def h(t, x):
+    def h(x):
         x1, _ = x
         return np.array([np.sin(x1)])
 
-    def dh(t, x):
+    def dh(x):
         x1, _ = x
         return np.array([[np.cos(x1), 0.0]])
 
@@ -357,17 +357,17 @@ def pendulum(
         input_dim=2,
         output_dim=2,
         state_trans_fun=f,
-        proc_noise_cov_mat_fun=lambda t: process_noise_cov,
+        proc_noise_cov_mat_fun=lambda: process_noise_cov,
         jacob_state_trans_fun=df,
-    )
+    ).as_continuous_transition()
 
     measurement_model = randprocs.markov.discrete.NonlinearGaussian(
         input_dim=2,
         output_dim=1,
         state_trans_fun=h,
-        proc_noise_cov_mat_fun=lambda t: measurement_variance * np.eye(1),
+        proc_noise_cov_mat_fun=lambda: measurement_variance * np.eye(1),
         jacob_state_trans_fun=dh,
-    )
+    ).as_continuous_transition()
 
     if initrv is None:
         initrv = randvars.Normal(np.ones(2), measurement_variance * np.eye(2))
@@ -470,7 +470,7 @@ def benes_daum(
         state_trans_mat=np.eye(1),
         shift_vec=np.zeros(1),
         proc_noise_cov_mat=measurement_variance * np.eye(1),
-    )
+    ).as_continuous_transition()
 
     # Generate data
     if time_grid is None:

--- a/src/probnum/randprocs/markov/continuous/_lti_sde.py
+++ b/src/probnum/randprocs/markov/continuous/_lti_sde.py
@@ -172,7 +172,7 @@ class LTISDE(_linear_sde.LinearSDE):
             qh,
             forward_implementation=self._forward_implementation_string,
             backward_implementation=self._backward_implementation_string,
-        )
+        ).as_continuous_transition()
 
 
 def _check_initial_state_dimensions(drift_matrix, force_vector, dispersion_matrix):

--- a/src/probnum/randprocs/markov/discrete/_lti_gaussian.py
+++ b/src/probnum/randprocs/markov/discrete/_lti_gaussian.py
@@ -56,12 +56,12 @@ class LTIGaussian(_linear_gaussian.LinearGaussian):
         output_dim, input_dim = state_trans_mat.shape
 
         super().__init__(
-            input_dim,
-            output_dim,
-            state_trans_mat_fun=lambda t: state_trans_mat,
-            shift_vec_fun=lambda t: shift_vec,
-            proc_noise_cov_mat_fun=lambda t: proc_noise_cov_mat,
-            proc_noise_cov_cholesky_fun=lambda t: proc_noise_cov_cholesky,
+            input_dim=input_dim,
+            output_dim=output_dim,
+            state_trans_mat_fun=lambda: state_trans_mat,
+            shift_vec_fun=lambda: shift_vec,
+            proc_noise_cov_mat_fun=lambda: proc_noise_cov_mat,
+            proc_noise_cov_cholesky_fun=lambda: proc_noise_cov_cholesky,
             forward_implementation=forward_implementation,
             backward_implementation=backward_implementation,
         )
@@ -72,7 +72,7 @@ class LTIGaussian(_linear_gaussian.LinearGaussian):
         self.proc_noise_cov_mat = proc_noise_cov_mat
         self._proc_noise_cov_cholesky = proc_noise_cov_cholesky
 
-    def proc_noise_cov_cholesky_fun(self, t):
+    def proc_noise_cov_cholesky_fun(self):
         return self.proc_noise_cov_cholesky
 
     @cached_property

--- a/src/probnum/randprocs/markov/discrete/_nonlinear_gaussian.py
+++ b/src/probnum/randprocs/markov/discrete/_nonlinear_gaussian.py
@@ -85,6 +85,10 @@ class _DiscreteAsContinuousTransition(_transition.Transition):
             _linearise_at=_linearise_at,
         )
 
+    # Special arguments.
+
+    # Nonlinear Gaussians:
+
     def state_trans_fun(self, t, x):
         return self._discrete_transition.state_trans_fun(x)
 
@@ -96,6 +100,44 @@ class _DiscreteAsContinuousTransition(_transition.Transition):
 
     def proc_noise_cov_cholesky_fun(self, t):
         return self._discrete_transition.proc_noise_cov_cholesky_fun()
+
+    # Linear Gaussians:
+
+    def state_trans_mat_fun(self, t):
+        return self._discrete_transition.state_trans_mat_fun()
+
+    def shift_vec_fun(self, t):
+        return self._discrete_transition.shift_vec_fun()
+
+    # Other wrappers:
+    def _forward_rv_classic(
+        self, rv, t, dt=None, compute_gain=False, _diffusion=1.0, _linearise_at=None
+    ):
+        return self._discrete_transition._forward_rv_classic(
+            rv=rv,
+            compute_gain=compute_gain,
+            _diffusion=_diffusion,
+            _linearise_at=_linearise_at,
+        )
+
+    def _forward_rv_sqrt(
+        self, rv, t, dt=None, compute_gain=False, _diffusion=1.0, _linearise_at=None
+    ):
+        return self._discrete_transition._forward_rv_sqrt(
+            rv=rv,
+            compute_gain=compute_gain,
+            _diffusion=_diffusion,
+            _linearise_at=_linearise_at,
+        )
+
+    def _backward_rv_classic(self, *args, t, **kwargs):
+        return self._discrete_transition._backward_rv_classic(*args, **kwargs)
+
+    def _backward_rv_sqrt(self, *args, t, **kwargs):
+        return self._discrete_transition._backward_rv_sqrt(*args, **kwargs)
+
+    def _backward_rv_joseph(self, *args, t, **kwargs):
+        return self._discrete_transition._backward_rv_joseph(*args, **kwargs)
 
 
 class NonlinearGaussian:
@@ -158,6 +200,14 @@ class NonlinearGaussian:
 
     def as_continuous_transition(self):
         return _DiscreteAsContinuousTransition(self)
+
+    def _backward_realization_via_backward_rv(self, realization, *args, **kwargs):
+        real_as_rv = randvars.Constant(support=realization)
+        return self.backward_rv(real_as_rv, *args, **kwargs)
+
+    def _forward_realization_via_forward_rv(self, realization, *args, **kwargs):
+        real_as_rv = randvars.Constant(support=realization)
+        return self.forward_rv(real_as_rv, *args, **kwargs)
 
     def forward_realization(
         self, realization, compute_gain=False, _diffusion=1.0, **kwargs

--- a/src/probnum/randprocs/markov/discrete/_nonlinear_gaussian.py
+++ b/src/probnum/randprocs/markov/discrete/_nonlinear_gaussian.py
@@ -1,6 +1,6 @@
 """Discrete transitions."""
 
-from functools import lru_cache
+from functools import cached_property, lru_cache
 from typing import Callable, Optional
 
 import numpy as np
@@ -108,6 +108,24 @@ class _DiscreteAsContinuousTransition(_transition.Transition):
 
     def shift_vec_fun(self, t):
         return self._discrete_transition.shift_vec_fun()
+
+    # LTI Gaussians
+
+    @cached_property
+    def proc_noise_cov_cholesky(self):
+        return self._discrete_transition.proc_noise_cov_cholesky
+
+    @property
+    def proc_noise_cov_mat(self):
+        return self._discrete_transition.proc_noise_cov_mat
+
+    @property
+    def shift_vec(self):
+        return self._discrete_transition.shift_vec
+
+    @property
+    def state_trans_mat(self):
+        return self._discrete_transition.state_trans_mat
 
     # Other wrappers:
     def _forward_rv_classic(

--- a/src/probnum/randprocs/markov/integrator/_iwp.py
+++ b/src/probnum/randprocs/markov/integrator/_iwp.py
@@ -212,7 +212,7 @@ class IntegratedWienerTransition(_integrator.IntegratorTransition, continuous.LT
             proc_noise_cov_cholesky=process_noise_cholesky,
             forward_implementation=self.forward_implementation,
             backward_implementation=self.backward_implementation,
-        )
+        ).as_continuous_transition()
 
     def forward_rv(
         self,
@@ -312,4 +312,4 @@ class IntegratedWienerTransition(_integrator.IntegratorTransition, continuous.LT
             proc_noise_cov_cholesky=proc_noise_cov_cholesky,
             forward_implementation=self.forward_implementation,
             backward_implementation=self.forward_implementation,
-        )
+        ).as_continuous_transition()

--- a/tests/test_randprocs/test_markov/test_continuous/test_lti_sde.py
+++ b/tests/test_randprocs/test_markov/test_continuous/test_lti_sde.py
@@ -39,10 +39,6 @@ class TestLTISDE(test_linear_sde.TestLinearSDE):
         self.dg = lambda t, x: self.G(t)
         self.l = lambda t, x: self.L(t)
 
-    def test_discretise(self):
-        out = self.transition.discretise(dt=0.1)
-        assert isinstance(out, randprocs.markov.discrete.LTIGaussian)
-
     def test_backward_rv(self, some_normal_rv1, some_normal_rv2):
         out, _ = self.transition.backward_rv(
             some_normal_rv1, some_normal_rv2, t=0.0, dt=0.1

--- a/tests/test_randprocs/test_markov/test_discrete/test_lti_gaussian.py
+++ b/tests/test_randprocs/test_markov/test_discrete/test_lti_gaussian.py
@@ -28,14 +28,14 @@ class TestLTIGaussian(test_linear_gaussian.TestLinearGaussian):
             self.S_const,
             forward_implementation=forw_impl_string_linear_gauss,
             backward_implementation=backw_impl_string_linear_gauss,
-        )
+        ).as_continuous_transition()
 
         # Compatibility with superclass' test
-        self.G = lambda t: self.G_const
-        self.S = lambda t: self.S_const
-        self.v = lambda t: self.v_const
-        self.g = lambda t, x: self.G(t) @ x + self.v(t)
-        self.dg = lambda t, x: self.G(t)
+        self.G = lambda: self.G_const
+        self.S = lambda: self.S_const
+        self.v = lambda: self.v_const
+        self.g = lambda x: self.G() @ x + self.v()
+        self.dg = lambda x: self.G()
 
     # Test access to system matrices
 

--- a/tests/test_randprocs/test_markov/test_discrete/test_nonlinear_gaussian.py
+++ b/tests/test_randprocs/test_markov/test_discrete/test_nonlinear_gaussian.py
@@ -19,9 +19,9 @@ class TestNonlinearGaussian(test_transition.InterfaceTestTransition):
     @pytest.fixture(autouse=True)
     def _setup(self, test_ndim, spdmat1):
 
-        self.g = lambda t, x: np.sin(x)
-        self.S = lambda t: spdmat1
-        self.dg = lambda t, x: np.cos(x)
+        self.g = lambda x: np.sin(x)
+        self.S = lambda: spdmat1
+        self.dg = lambda x: np.cos(x)
         self.transition = randprocs.markov.discrete.NonlinearGaussian(
             test_ndim,
             test_ndim,
@@ -29,18 +29,18 @@ class TestNonlinearGaussian(test_transition.InterfaceTestTransition):
             self.S,
             self.dg,
             None,
-        )
+        ).as_continuous_transition()
 
     # Test access to system matrices
 
     def test_state_transition(self, some_normal_rv1):
         received = self.transition.state_trans_fun(0.0, some_normal_rv1.mean)
-        expected = self.g(0.0, some_normal_rv1.mean)
+        expected = self.g(some_normal_rv1.mean)
         np.testing.assert_allclose(received, expected)
 
     def test_process_noise(self):
         received = self.transition.proc_noise_cov_mat_fun(0.0)
-        expected = self.S(0.0)
+        expected = self.S()
         np.testing.assert_allclose(received, expected)
 
     def test_process_noise_cholesky(self):
@@ -50,7 +50,7 @@ class TestNonlinearGaussian(test_transition.InterfaceTestTransition):
 
     def test_jacobian(self, some_normal_rv1):
         received = self.transition.jacob_state_trans_fun(0.0, some_normal_rv1.mean)
-        expected = self.dg(0.0, some_normal_rv1.mean)
+        expected = self.dg(some_normal_rv1.mean)
         np.testing.assert_allclose(received, expected)
 
     # Test forward and backward implementations

--- a/tests/test_randprocs/test_markov/test_integrator/test_iwp.py
+++ b/tests/test_randprocs/test_markov/test_integrator/test_iwp.py
@@ -100,7 +100,6 @@ class TestIntegratedWienerTransition(
 
         # Test discretisation
         self.transition.discretise(dt=0.1)
-        # assert isinstance(out, randprocs.markov.discrete.LTIGaussian)
 
 
 class TestIWPLinOps(test_lti_sde.TestLTISDE, test_integrator.TestIntegratorTransition):
@@ -190,7 +189,6 @@ class TestIWPLinOps(test_lti_sde.TestLTISDE, test_integrator.TestIntegratorTrans
 
         # Test discretisation
         self.transition.discretise(dt=0.1)
-        # assert isinstance(out, randprocs.markov.discrete.LTIGaussian)
 
 
 @pytest.fixture

--- a/tests/test_randprocs/test_markov/test_integrator/test_iwp.py
+++ b/tests/test_randprocs/test_markov/test_integrator/test_iwp.py
@@ -99,8 +99,8 @@ class TestIntegratedWienerTransition(
         np.testing.assert_allclose(self.transition.force_vector, 0.0)
 
         # Test discretisation
-        out = self.transition.discretise(dt=0.1)
-        assert isinstance(out, randprocs.markov.discrete.LTIGaussian)
+        self.transition.discretise(dt=0.1)
+        # assert isinstance(out, randprocs.markov.discrete.LTIGaussian)
 
 
 class TestIWPLinOps(test_lti_sde.TestLTISDE, test_integrator.TestIntegratorTransition):
@@ -189,8 +189,8 @@ class TestIWPLinOps(test_lti_sde.TestLTISDE, test_integrator.TestIntegratorTrans
         np.testing.assert_allclose(self.transition.force_vector, 0.0)
 
         # Test discretisation
-        out = self.transition.discretise(dt=0.1)
-        assert isinstance(out, randprocs.markov.discrete.LTIGaussian)
+        self.transition.discretise(dt=0.1)
+        # assert isinstance(out, randprocs.markov.discrete.LTIGaussian)
 
 
 @pytest.fixture

--- a/tests/test_randprocs/test_markov/test_integrator/test_iwp.py
+++ b/tests/test_randprocs/test_markov/test_integrator/test_iwp.py
@@ -103,7 +103,7 @@ class TestIntegratedWienerTransition(
         assert isinstance(out, randprocs.markov.discrete.LTIGaussian)
 
 
-class TestIBMLinOps(test_lti_sde.TestLTISDE, test_integrator.TestIntegratorTransition):
+class TestIWPLinOps(test_lti_sde.TestLTISDE, test_integrator.TestIntegratorTransition):
 
     # Replacement for an __init__ in the pytest language. See:
     # https://stackoverflow.com/questions/21430900/py-test-skips-test-class-if-constructor-is-defined


### PR DESCRIPTION
This is the first of a bunch of PRs that  refactor discrete and continuous transitions. More specifically, that split the discrete from the continuous transitions. 

This PR does precisely this: it makes `NonlinearGaussian` a base-class (i.e. cuts the inheritance from `Transition`). It removes `t` and `dt` from the inputs to forward_* and backward_* (because they dont belong there). It also introduces a wrapper `_DiscreteAsContinuousTransition` which wraps the "new" discrete transitions into the old interface in order to not change too much at once. Since this is a bit unfinished, I am going to collect these transitions in a `collect-*` branch before setting a formal pull request. 

Future PRs will be (no particular ordering): 
* process noise in discrete transitions becomes a random variable (this way, mean, cov, and cov_cholesky are bundled naturally, and are guaranteed to use the same language as random variables)
* linear and lti transitions merge (they are now the same class, but are not implemented as such yet)
* discrete Kalman filtering and smoothing becomes its own thing (
* MarkovSequence prior for discrete transitions (because it is not the same object as the MarkovProcess. For example, dense output does not really make sense)
* rename forward_*/backward_* into forward(), forward_marginal(), backward(), and backward_marginal() which is something that should probably also happen for the continuous transitions.
* remove the compute_gain flags, but make different methods: `forward_marginal_with_gain` or something.
* remove _diffusion argument, govern that with lists of transitions in potential posterior objects. This should probably also happen for the continuous transitions at some point. 
* remove linearise_at() argument and make `discrete.linearize.ek1(NonlinearGaussian) -> LinearGaussian`, and corresponding UK methods.
* introduce semilinear models: this way, EK0 approximation does make sense and ODE solver approximation operators could be outsourced entirely to randprocs. This would simplify the approx_strategy() in diffeq.odefilter() drastically. 
